### PR TITLE
Add helper for Ollama connection

### DIFF
--- a/autogen/README.md
+++ b/autogen/README.md
@@ -1,0 +1,29 @@
+# Autogen Kubernetes Workflow
+
+This directory contains a minimal Autogen application and utility scripts.
+
+## `mdmp_ghost_workflow.py`
+
+Runs an example MDMP workflow for deploying a Ghost website using the HQ agent
+matrix. It reads the CSV template under `src/templates/MDMP_ghost_website.csv`
+and issues each step as a prompt to a local LLM via the Autogen library.
+
+### Usage
+
+```bash
+python -m autogen.src.mdmp_ghost_workflow
+```
+
+The script expects an Ollama instance reachable at `$OLLAMA_URL` (defaults to
+`http://127.0.0.1:11434`). It prints each step's LLM response to standard
+output.
+
+## `ollama_helper.py`
+
+Provides `wait_for_server()` to confirm a local Ollama instance is up. The
+function probes the `$OLLAMA_URL` and waits up to 30 seconds. Run it directly to
+print the detected URL:
+
+```bash
+python -m autogen.src.ollama_helper
+```

--- a/autogen/src/mdmp_ghost_workflow.py
+++ b/autogen/src/mdmp_ghost_workflow.py
@@ -1,0 +1,56 @@
+import csv
+import os
+from pathlib import Path
+
+from autogen import AssistantAgent, UserProxyAgent
+from autogen.llm_config import LLMConfig
+from autogen.oai.ollama import OllamaLLMConfigEntry
+from .ollama_helper import wait_for_server
+
+TEMPLATE_PATH = Path(__file__).parent / "templates" / "MDMP_ghost_website.csv"
+
+
+def load_steps(path: Path):
+    """Return a list of (step, agent_task, outputs) tuples."""
+    steps = []
+    with path.open(encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            step = row["MDMP Step"].strip() or "Supporting"
+            task = row["AI Agent & Core Task"].strip()
+            outputs = row["Key Outputs / Checks"].strip()
+            steps.append((step, task, outputs))
+    return steps
+
+
+def build_agents():
+    url = wait_for_server()
+    model = os.getenv("SMALL_MODEL", "tinyllama:1.1b")
+    entry = OllamaLLMConfigEntry(
+        model=model,
+        api_key="ollama",
+        client_host=url,
+    )
+    llm_cfg = LLMConfig(config_list=[entry], temperature=0.2)
+    assistant = AssistantAgent("ops-assistant", llm_config=llm_cfg, human_input_mode="NEVER")
+    user = UserProxyAgent("user", human_input_mode="NEVER")
+    return assistant, user
+
+
+def run_workflow():
+    assistant, user = build_agents()
+    for step, task, outputs in load_steps(TEMPLATE_PATH):
+        prompt = (
+            f"Step: {step}\n"
+            f"Role: {task}\n"
+            f"Goal: {outputs}\n"
+            "Provide your recommended actions or manifests."
+        )
+        user.initiate_chat(assistant, message=prompt)
+        print(f"\n=== {step} ===")
+        print(assistant.last_message()["content"])  # raw LLM response
+        print()
+
+
+if __name__ == "__main__":
+    run_workflow()

--- a/autogen/src/ollama_helper.py
+++ b/autogen/src/ollama_helper.py
@@ -1,0 +1,39 @@
+import os
+import time
+import requests
+
+
+DEFAULT_URL = "http://127.0.0.1:11434"
+
+
+def wait_for_server(url: str | None = None, timeout: float = 30.0) -> str:
+    """Return the Ollama URL after verifying the server responds.
+
+    Parameters
+    ----------
+    url : str, optional
+        Base URL to probe. Defaults to the ``OLLAMA_URL`` env variable or
+        ``DEFAULT_URL`` if unset.
+    timeout : float
+        Seconds to wait before giving up.
+
+    Raises
+    ------
+    RuntimeError
+        If the server is unreachable within ``timeout`` seconds.
+    """
+    url = url or os.getenv("OLLAMA_URL", DEFAULT_URL)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            r = requests.get(f"{url}/api/tags", timeout=3)
+            if r.ok:
+                return url
+        except Exception:
+            pass
+        time.sleep(1)
+    raise RuntimeError(f"Ollama server not reachable at {url}")
+
+
+if __name__ == "__main__":
+    print("Ollama URL:", wait_for_server())


### PR DESCRIPTION
## Summary
- document Ollama helper
- add `ollama_helper.py` with `wait_for_server`
- import helper in `mdmp_ghost_workflow.py`

## Testing
- `pip install -q requests`
- `pytest -q` *(fails: ConnectionError to 127.0.0.1:11434)*


------
https://chatgpt.com/codex/tasks/task_e_686d085fc36c83259261c19d7aa0582b